### PR TITLE
Fix logic to cater for holes in memory

### DIFF
--- a/src/Zem80_Core/Memory/MemoryBank.cs
+++ b/src/Zem80_Core/Memory/MemoryBank.cs
@@ -161,7 +161,7 @@ namespace Zem80.Core.Memory
             if (!_initialised) throw new MemoryNotInitialisedException();
 
             IMemorySegment segment = _map.SegmentFor(address);
-            if (segment != null || !segment.ReadOnly)
+            if (segment != null && !segment.ReadOnly)
             {
                 segment.WriteByteAt(AddressOffset(address, segment), value);
             }
@@ -175,7 +175,7 @@ namespace Zem80.Core.Memory
             if (!_initialised) throw new MemoryNotInitialisedException();
 
             IMemorySegment segment = _map.SegmentFor(address);
-            if (segment != null || !segment.ReadOnly)
+            if (segment != null && !segment.ReadOnly)
             {
                 if (!timing && segment.SizeInBytes - AddressOffset(address, segment) >= bytes.Length)
                 {


### PR DESCRIPTION
Hi Neil,  

I found an issue with the memory bank Write implementation when trying to use your emulation with a machine with a gap in the memory.  This pull request should fix the issue.

Daivd